### PR TITLE
Fix empty data message in chart view

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -378,7 +378,7 @@ export default function Home() {
                             />
                         ) : (
                             <div className="flex items-center justify-center h-full">
-                                <p className="text-secondary">No results found</p>
+                                <p className="text-secondary text-lg">No data available for the selected date range</p>
                             </div>
                         )}
                     </div>


### PR DESCRIPTION
When a date filter is set and returns no data, the chart now displays a more descriptive message: "No data available for the selected date range" instead of "No results found".