### PR TITLE
Auto-close speed test success message after 5 seconds

### DIFF
--- a/frontend/app/components/Settings.tsx
+++ b/frontend/app/components/Settings.tsx
@@ -59,7 +59,7 @@ export default function Settings() {
             if (!response.ok) throw new Error('Failed to run speed test');
             const result = await response.json();
             setSuccess('Speed test started successfully');
-            console.log(result);
+            setTimeout(() => setSuccess(null), 5000);
         } catch (err) {
             setError(`Failed to run speed test: ${err}`);
         }


### PR DESCRIPTION
This PR adds automatic closing of the "Speed test started successfully" message after 5 seconds when clicking the "Run Speed Test Now" button.

Changes:
- Added a setTimeout to clear the success message after 5 seconds in the runSpeedTestNow function