### PR TITLE
Add DataStatistics component

### DIFF
--- a/frontend/app/components/DataStatistics.tsx
+++ b/frontend/app/components/DataStatistics.tsx
@@ -1,0 +1,36 @@
+import { Serie } from '@nivo/line';
+
+interface DataStatisticsProps {
+    chartData: Serie[];
+}
+
+export default function DataStatistics({ chartData }: DataStatisticsProps) {
+    const calculateAverage = (data: Serie[], id: string) => {
+        const series = data.find(series => series.id === id);
+        if (!series || !series.data.length) return 0;
+        
+        const sum = series.data.reduce((acc, point) => acc + (point.y as number), 0);
+        return (sum / series.data.length).toFixed(2);
+    };
+
+    const uploadAvg = calculateAverage(chartData, 'Upload');
+    const downloadAvg = calculateAverage(chartData, 'Download');
+    const pingAvg = calculateAverage(chartData, 'Ping');
+
+    return (
+        <div className="glass-card p-6 grid grid-cols-3 gap-4">
+            <div className="text-center">
+                <h3 className="text-lg font-semibold mb-2">Average Download</h3>
+                <p className="text-2xl">{downloadAvg} <span className="text-sm">Mbps</span></p>
+            </div>
+            <div className="text-center">
+                <h3 className="text-lg font-semibold mb-2">Average Upload</h3>
+                <p className="text-2xl">{uploadAvg} <span className="text-sm">Mbps</span></p>
+            </div>
+            <div className="text-center">
+                <h3 className="text-lg font-semibold mb-2">Average Ping</h3>
+                <p className="text-2xl">{pingAvg} <span className="text-sm">ms</span></p>
+            </div>
+        </div>
+    );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -8,6 +8,7 @@ import Settings from './components/Settings';
 import SpeedTestChart from './components/SpeedTestChart';
 import Filters from './components/Filters';
 import Pagination from './components/Pagination';
+import DataStatistics from './components/DataStatistics';
 
 interface FetchFilters {
     startDate?: string;
@@ -168,6 +169,7 @@ export default function Home() {
                         onNextPage={handleNextPage}
                     />
 
+                    <DataStatistics chartData={chartData} />
                     <SpeedTestChart chartData={chartData} />
                 </div>
             </div>


### PR DESCRIPTION
This PR adds a new DataStatistics component that displays average metrics for upload speed, download speed, and ping. The component is placed above the chart and uses the same styling for consistency.

Changes:
- Created new DataStatistics component
- Added component to the main page layout
- Displays averages with appropriate units (Mbps/ms)
- Uses consistent styling with glass-card effect